### PR TITLE
Remove "Relatórios" from navbar

### DIFF
--- a/templates/navbar.html.twig
+++ b/templates/navbar.html.twig
@@ -17,9 +17,6 @@
                     <li class="nav-item">
                         <a class="nav-link text-white" href="/installments">Parcelas</a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link text-white" href="/">Relatórios</a>
-                    </li>
                 </ul>
                 {% if is_granted('IS_AUTHENTICATED_FULLY') %}
                     <a href="{{ logout_path() }}" class="nav-link text-white">Sair</a>


### PR DESCRIPTION
Since it doesn't redirect to any page yet, we've decided to remove it from navbar for now.