### PR TITLE
Add missing link to partial payment message

### DIFF
--- a/templates/installment/new-loan-message.html.twig
+++ b/templates/installment/new-loan-message.html.twig
@@ -25,7 +25,7 @@
         <div class="row">
             <div class="col">
                 <a href="/create_loan?customer={{customer.id}}&value={{value}}" class="btn btn-success">Sim, gerar novo empréstimo</a>
-                <a class="btn btn-link">Não, apenas prosseguir</a>
+                <a href="/installments" class="btn btn-link">Não, apenas prosseguir</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
We have a message displayed when the last installment is paid partially. It has two links, and one of them was not working.

This PR fixes it by redirecting the option "Não, apenas prosseguir" to the installments list.