### PR TITLE
Leave "Payment date" column empty when no payment date

### DIFF
--- a/templates/installment/index.html.twig
+++ b/templates/installment/index.html.twig
@@ -59,11 +59,11 @@
                                 <td>{{ installment.loan.customer.documentnumber }}</td>
                                 <td>{{ 'R$ ' ~ installment.value }}</td>
                                 <td>{{ installment.duedate | date('d/m/Y') }}</td>
-                                {% if installment.paydate %}
-                                    <td>{{ installment.paydate | date('d/m/Y') }}</td>
-                                {% else %}
-                                    <td>Não efetuado</td>
-                                {% endif %}
+                                <td>
+                                    {% if installment.paydate %}
+                                        {{ installment.paydate | date('d/m/Y') }}</td>
+                                    {% endif %}
+                                </td>
                                 <td>
                                     {% if installment.status.isPaid %}
                                         <span class="badge badge-pill badge-success">{{ installment.status.name }}</span>


### PR DESCRIPTION
Before we had "Not paid" value when there was no payment date (regardless the status). However, we must consider all old values in database won't have this value even being paid. We just decided to leave it empty to not confuse the final user.